### PR TITLE
Fix: Change webpack to be a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "babel-eslint": "^7.1.1",
     "fs-extra": "^0.18.3",
     "mocha": "^2.4.5",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "webpack": "^1.13.0"
   },
   "optionalDependencies": {
-    "uglify-js": "^3.0.10",
-    "webpack": "^1.13.0"
+    "uglify-js": "^3.0.10"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Hey,
Some projects that use payments as a dependency get `webpack@1` for no reason.
Please approve this,
Thanks :)